### PR TITLE
Add keycap styling with sample text

### DIFF
--- a/_posts/1992-02-01-test.md
+++ b/_posts/1992-02-01-test.md
@@ -89,6 +89,8 @@ Neat! I'm sure we can spruce those up a bit more later. Now, let's try to embed 
 
 Okay so that was a little more complicated than I'd like, but it actually works. Neato 🌯️.
 
+And of course, pressing <kbd>⌘</kbd> + <kbd>Shift</kbd> will do absolutely nothing. Thought you'd like to know.
+
 ## But wait, there's more!
 
 To help contribute, visit [github.com/elementary/blog-template](https://github.com/elementary/blog-template)

--- a/_sass/_typography.scss
+++ b/_sass/_typography.scss
@@ -131,7 +131,7 @@ kbd {
   border: 1px solid rgba(0, 0, 0, 0.30);
   border-radius: 0.2em;
   box-shadow:
-    inset 0 1px 0 0 #fff,
+    inset 0 1px 0 0 rgba(255, 255, 255, 0.12),
     inset 0 -2px 0 0 #d9d9d9;
   display: inline-block;
   font-family: var(--ui-font);

--- a/_sass/_typography.scss
+++ b/_sass/_typography.scss
@@ -137,7 +137,7 @@ kbd {
   font-family: var(--ui-font);
   font-size: 80%;
   line-height: 1.5;
-  margin: 3px;
+  margin: 0 0.2em;
   min-width: 22px;
   padding: 0.125em 0.5em;
   text-align: center;

--- a/_sass/_typography.scss
+++ b/_sass/_typography.scss
@@ -128,7 +128,7 @@ aside {
 
 kbd {
   background-color: rgba(200, 200, 200, 0.15);
-  border: 1px solid #bfbfbf;
+  border: 1px solid rgba(0, 0, 0, 0.30);
   border-radius: 3px;
   box-shadow:
     inset 0 1px 0 0 #fff,

--- a/_sass/_typography.scss
+++ b/_sass/_typography.scss
@@ -139,7 +139,7 @@ kbd {
   line-height: 1.5;
   margin: 3px;
   min-width: 22px;
-  padding: 2px 4px;
+  padding: 0.125em 0.5em;
   text-align: center;
   user-select: none;
   white-space: nowrap;

--- a/_sass/_typography.scss
+++ b/_sass/_typography.scss
@@ -134,7 +134,7 @@ kbd {
     inset 0 1px 0 0 #fff,
     inset 0 -2px 0 0 #d9d9d9;
   display: inline-block;
-  font-family: "Roboto Mono", monospace;
+  font-family: var(--ui-font);
   font-size: 80%;
   line-height: 1.5;
   margin: 3px;

--- a/_sass/_typography.scss
+++ b/_sass/_typography.scss
@@ -132,7 +132,7 @@ kbd {
   border-radius: 0.2em;
   box-shadow:
     inset 0 1px 0 0 rgba(255, 255, 255, 0.12),
-    inset 0 -2px 0 0 #d9d9d9;
+    inset 0 -2px 0 0 rgba(0, 0, 0, 0.15);
   display: inline-block;
   font-family: var(--ui-font);
   font-size: 80%;

--- a/_sass/_typography.scss
+++ b/_sass/_typography.scss
@@ -126,3 +126,22 @@ aside {
   margin-bottom: 2em;
 }
 
+kbd {
+  background-color: #f0f0f0;
+  border: 1px solid #bfbfbf;
+  border-radius: 3px;
+  box-shadow:
+    inset 0 1px 0 0 #fff,
+    inset 0 -2px 0 0 #d9d9d9;
+  display: inline-block;
+  font-family: "Roboto Mono", monospace;
+  font-size: 80%;
+  line-height: 1.5;
+  margin: 3px;
+  min-width: 22px;
+  padding: 2px 4px;
+  text-align: center;
+  user-select: none;
+  white-space: nowrap;
+}
+

--- a/_sass/_typography.scss
+++ b/_sass/_typography.scss
@@ -138,7 +138,7 @@ kbd {
   font-size: 80%;
   line-height: 1.5;
   margin: 0 0.2em;
-  min-width: 22px;
+  min-width: 1em;
   padding: 0.125em 0.5em;
   text-align: center;
   user-select: none;

--- a/_sass/_typography.scss
+++ b/_sass/_typography.scss
@@ -129,7 +129,7 @@ aside {
 kbd {
   background-color: rgba(200, 200, 200, 0.15);
   border: 1px solid rgba(0, 0, 0, 0.30);
-  border-radius: 3px;
+  border-radius: 0.2em;
   box-shadow:
     inset 0 1px 0 0 #fff,
     inset 0 -2px 0 0 #d9d9d9;

--- a/_sass/_typography.scss
+++ b/_sass/_typography.scss
@@ -127,7 +127,7 @@ aside {
 }
 
 kbd {
-  background-color: #f0f0f0;
+  background-color: rgba(200, 200, 200, 0.15);
   border: 1px solid #bfbfbf;
   border-radius: 3px;
   box-shadow:


### PR DESCRIPTION
Fixes #7 

I looked at these lines from the main site:

https://github.com/elementary/website/blob/2cf01ae216ba8b3598bdfd6b0ac55545581ad071/_styles/docs.css#L118-L142

And made a few necessary changes. This is what the result looks like:

![image](https://user-images.githubusercontent.com/8205055/65907659-60f08400-e3e2-11e9-8a79-cebdc0d6f223.png)

The font size is larger than that on the main site, but so is the rest of the text, so I chose to keep it this way.

Does this look right?

Also, what should I do about the hex codes? The colors used here aren't defined as variables yet.