### PR TITLE
Use arrow symbols instead of guillemets for "Newer"/"Older" links

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -64,11 +64,11 @@ nav.pagination {
     padding: 1em;
 
     &.next::after {
-      content: " »";
+      content: " →";
     }
 
     &.previous::before {
-      content: "« ";
+      content: "← ";
     }
   }
 }


### PR DESCRIPTION
Fixes #1 

Preview:

![image](https://user-images.githubusercontent.com/8205055/65975752-b71a0180-e48c-11e9-8d57-2c730e388ea8.png)
