### PR TITLE
Unify styling of code blocks inside and outside of figure

### DIFF
--- a/_posts/1992-02-01-test.md
+++ b/_posts/1992-02-01-test.md
@@ -115,6 +115,33 @@ public class MyApp : Gtk.Application {
 }
 ```
 
+And inside `<figure>`, they look like this:
+
+<figure markdown="1">
+```vala
+public class MyApp : Gtk.Application {
+
+    public MyApp () {
+        Object (application_id: "com.github.myteam.myapp",
+        flags: ApplicationFlags.FLAGS_NONE);
+    }
+
+    protected override void activate () {
+        var window = new Gtk.ApplicationWindow (this);
+        window.title = "MyApp";
+        window.set_default_size (1024, 768);
+        window.show_all ();
+    }
+
+    public static int main (string[] args) {
+        var app = new MyApp ();
+        return app.run (args);
+    }
+}
+```
+<figcaption>Some Vala code</figcaption>
+</figure>
+
 ## But wait, there's more!
 
 To help contribute, visit [github.com/elementary/blog-template](https://github.com/elementary/blog-template)

--- a/_sass/_code.scss
+++ b/_sass/_code.scss
@@ -13,18 +13,9 @@
   }
 }
 
-.highlight {
-
-
-  table {
-    margin: auto;
-  }
-}
-
 .rouge-code {
   padding-left: 0.25em;
 }
-
 
 .highlight {
   display: inline-block;
@@ -32,9 +23,18 @@
   line-height: 1.33em;
   margin: auto;
   overflow: auto;
+  max-width: 100%;
   text-align: left;
   background-color: var(--solarized-base3);
   color: var(--solarized-base01);
+
+  table {
+    margin: auto;
+  }
+
+  pre {
+    margin: 0;
+  }
 
   .gl {
     background-color: var(--solarized-base2);

--- a/_sass/_figures.scss
+++ b/_sass/_figures.scss
@@ -4,7 +4,7 @@ figure {
   position: relative;
   text-align: center;
 
-  * {
+  > * {
     margin: 0;
     max-width: 100%;
   }


### PR DESCRIPTION
- Set figure margin and max-width only to the direct children of figure (`figure *` -> `figure > *`)
- Keep code styling the same after the above change (`.highlight { pre {  margin: 0; } }`)
- Allow for scrolling through long code horizontally even when it's outside of figure (`.highlight { max-width: 100%; }`)