### PR TITLE
Authors Page

### DIFF
--- a/_includes/byline.html
+++ b/_includes/byline.html
@@ -21,7 +21,9 @@
     />
   </div>
   <div class="author">
+    {% if page.layout == 'post' %}<a href="{{ site.baseurl }}/authors/#{{ include.author }}">{% endif %}
     <span class="name">{{ author.name }}</span>
+    {% if page.layout == 'post' %}</a>{% endif %}
     {% if author.description and page.layout == 'post' %}
       <span class="description">{{ author.description }}</span>
     {% endif %}

--- a/_sass/_byline.scss
+++ b/_sass/_byline.scss
@@ -44,6 +44,17 @@
     }
   }
 
+  a {
+    color: inherit;
+    opacity: 1;
+    text-decoration: none;
+
+    &:hover {
+      color: var(--accent-color);
+      text-decoration: underline;
+    }
+  }
+
   .name {
     font-weight: 600;
     opacity: 0.8;

--- a/authors.md
+++ b/authors.md
@@ -3,14 +3,14 @@
 
 # Authors
 
-<section class="tag-list">
+<section class="author-list">
 {% assign site_authors = site.authors | sort %}
 {% for each_author in site_authors %}
   {% if each_author[0] != 'anonymous' %}
     {% assign posts = site.posts | where: "author", each_author[0] | sort | reverse %}
     {% if posts.size > 1 %}
       <hr />
-      <h2 id="{{ author[0] }}">{{ each_author[1].name }}</h2>
+      <h2 id="{{ each_author[0] }}">{{ each_author[1].name }}</h2>
       <p>{{ each_author[1].description }}</p>
       {% for post in posts %}
         {% unless post.hidden %}

--- a/authors.md
+++ b/authors.md
@@ -1,0 +1,23 @@
+---
+---
+
+# Authors
+
+<section class="tag-list">
+{% assign site_authors = site.authors | sort %}
+{% for each_author in site_authors %}
+  {% if each_author[0] != 'anonymous' %}
+    {% assign posts = site.posts | where: "author", each_author[0] | sort | reverse %}
+    {% if posts.size > 1 %}
+      <hr />
+      <h2 id="{{ author[0] }}">{{ each_author[1].name }}</h2>
+      <p>{{ each_author[1].description }}</p>
+      {% for post in posts %}
+        {% unless post.hidden %}
+          {% include featured.html post=post %}
+        {% endunless %}
+      {% endfor %}
+    {% endif %}
+  {% endif %}
+{% endfor %}
+</section>

--- a/tags.md
+++ b/tags.md
@@ -1,10 +1,14 @@
 ---
 ---
+# Tags
+
 <section class="tag-list">
 {% assign tags = site.tags | sort %}
 {% for tag in tags %}
   {% if tag[1].size > 1 %}
-    <h1 id="{{ tag[0] | replace: ' ', '-' }}">#{{ tag[0] }}</h1>
+    <hr />
+    {% assign id = tag[0] | replace: ' ', '-' %}
+    <a href="#{{ id }}"><h2 id="{{ id }}">#{{ tag[0] }}</h2></a>
     {% assign posts = tag[1] | sort | reverse %}
     {% for post in posts %}
       {% unless post.hidden %}


### PR DESCRIPTION
Adds a new Authors page at `/authors` that lists all authors with posts attributed to them. Also links the name of the author on their posts to their section on the authors page.