### PR TITLE
Refine Twitter cards

### DIFF
--- a/_includes/twitter-card.html
+++ b/_includes/twitter-card.html
@@ -18,7 +18,7 @@
   <footer>
     <a href="{{ permalink }}">
       <span>View on Twitter →</span>
-      <time>{{ include.timestamp }}</time>
+      <time datetime="{{ include.timestamp | date:"%Y-%m-%d" }}">{{ include.timestamp | date: "%b %e, %Y" }}</time>
     </a>
   </footer>
 </div>

--- a/_includes/twitter-card.html
+++ b/_includes/twitter-card.html
@@ -1,12 +1,24 @@
+{% assign profile = include.account | prepend: "https://twitter.com/" %}
+{% assign permalink = include.id | prepend: "/status/" | prepend: profile %}
+
 <div class="twitter-card">
-  <a href="{{ include.href }}">
-    <div class="header">
-        <img class="avatar" src="{{ include.avatar }}" />
-        <strong>{{ include.name }}</strong>
-        <p>{{ include.account }}</p>
-        <img class="logo" src="/images/twitter.svg" />
-    </div>
-    <p>{{ include.contents }}</p>
-    <p class="timestamp">{{ include.timestamp }}</p>
-  </a>
+  <header>
+    <a class="account" href="{{ profile }}">
+      <img class="avatar" src="{{ include.avatar }}" />
+      <strong>{{ include.name }}</strong>
+      <p>@{{ include.account }}</p>
+    </a>
+    <a href="{{ permalink }}">
+      <img class="logo" src="/images/twitter.svg" />
+    </a>
+  </header>
+
+  <p>{{ include.contents }}</p>
+
+  <footer>
+    <a href="{{ permalink }}">
+      <span>View on Twitter →</span>
+      <time>{{ include.timestamp }}</time>
+    </a>
+  </footer>
 </div>

--- a/_posts/2020-07-16-twitter-embeds.md
+++ b/_posts/2020-07-16-twitter-embeds.md
@@ -11,7 +11,7 @@ Check it out:
   account="CassidyJames"
   avatar="https://gravatar.com/avatar/41275ecc8271aca852ce2c0ff72d2610?s=128"
   id="1281816033343537152"
-  timestamp="Jul 10, 2020"
+  timestamp="2020-07-10"
   contents="Got my PINEBOOK Pro! Super duper first impressions: damn, this
     hardware quality is nice for the price. I would love to see what they could
     do around the $500–750 price, honestly. Performance is great; I would not
@@ -26,7 +26,7 @@ Turns into:
   account="CassidyJames"
   avatar="https://gravatar.com/avatar/41275ecc8271aca852ce2c0ff72d2610?s=128"
   id="1281816033343537152"
-  timestamp="Jul 10, 2020"
+  timestamp="2020-07-10"
   contents="Got my PINEBOOK Pro! Super duper first impressions: damn, this
     hardware quality is nice for the price. I would love to see what they could
     do around the $500–750 price, honestly. Performance is great; I would not

--- a/_posts/2020-07-16-twitter-embeds.md
+++ b/_posts/2020-07-16-twitter-embeds.md
@@ -8,10 +8,10 @@ Check it out:
 ```liquid
 {% include twitter-card.html
   name="Twitter"
-  account="@twitter"
+  account="twitter"
   avatar="/images/twitter.svg"
   href="https://twitter.com/"
-  timestamp="3:59 PM · Jul 16, 2020"
+  timestamp="Jul 16, 2020"
   contents="A fake tweet, as a demo"
 %}
 ```
@@ -19,12 +19,12 @@ Check it out:
 Turns into:
 
 {% include twitter-card.html
-  name="Twitter"
-  account="@twitter"
-  avatar="/images/twitter.svg"
-  href="https://twitter.com/"
-  timestamp="3:59 PM · Jul 16, 2020"
-  contents="A fake tweet, as a demo"
+  name="Cassidy James Blaede"
+  account="CassidyJames"
+  avatar="https://www.gravatar.com/avatar/41275ecc8271aca852ce2c0ff72d2610?s=128&d=blank"
+  id="1281816033343537152"
+  timestamp="Jul 10, 2020"
+  contents="Got my PINEBOOK Pro! Super duper first impressions: damn, this hardware quality is nice for the price. I would love to see what they could do around the $500–750 price, honestly. Performance is great; I would not guess it was ARM just from using it. It’s fanless!"
 %}
 
 It's even light/dark style aware!

--- a/_posts/2020-07-16-twitter-embeds.md
+++ b/_posts/2020-07-16-twitter-embeds.md
@@ -6,14 +6,17 @@ author: cassidyjames
 Check it out:
 
 ```liquid
-{% include twitter-card.html
-  name="Twitter"
-  account="twitter"
-  avatar="/images/twitter.svg"
-  href="https://twitter.com/"
-  timestamp="Jul 16, 2020"
-  contents="A fake tweet, as a demo"
-%}
+{% raw %}{% include twitter-card.html
+  name="Cassidy James Blaede"
+  account="CassidyJames"
+  avatar="https://gravatar.com/avatar/41275ecc8271aca852ce2c0ff72d2610?s=128"
+  id="1281816033343537152"
+  timestamp="Jul 10, 2020"
+  contents="Got my PINEBOOK Pro! Super duper first impressions: damn, this
+    hardware quality is nice for the price. I would love to see what they could
+    do around the $500–750 price, honestly. Performance is great; I would not
+    guess it was ARM just from using it. It’s fanless!"
+%}{% endraw %}
 ```
 
 Turns into:
@@ -21,10 +24,13 @@ Turns into:
 {% include twitter-card.html
   name="Cassidy James Blaede"
   account="CassidyJames"
-  avatar="https://www.gravatar.com/avatar/41275ecc8271aca852ce2c0ff72d2610?s=128&d=blank"
+  avatar="https://gravatar.com/avatar/41275ecc8271aca852ce2c0ff72d2610?s=128"
   id="1281816033343537152"
   timestamp="Jul 10, 2020"
-  contents="Got my PINEBOOK Pro! Super duper first impressions: damn, this hardware quality is nice for the price. I would love to see what they could do around the $500–750 price, honestly. Performance is great; I would not guess it was ARM just from using it. It’s fanless!"
+  contents="Got my PINEBOOK Pro! Super duper first impressions: damn, this
+    hardware quality is nice for the price. I would love to see what they could
+    do around the $500–750 price, honestly. Performance is great; I would not
+    guess it was ARM just from using it. It’s fanless!"
 %}
 
 It's even light/dark style aware!

--- a/_sass/_twitter-cards.scss
+++ b/_sass/_twitter-cards.scss
@@ -74,6 +74,6 @@
   }
 
   @media (prefers-color-scheme: dark) {
-    background-color: var(--silver-900);
+    background-color: var(--black-500);
   }
 }

--- a/_sass/_twitter-cards.scss
+++ b/_sass/_twitter-cards.scss
@@ -11,7 +11,12 @@
 
   a {
     color: inherit;
+    opacity: 1;
     text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
   }
 
   p {
@@ -19,50 +24,53 @@
     margin-bottom: 0.5em;
   }
 
-  .header {
-    display: grid;
-    grid-template-columns: max-content;
-    margin-bottom: 0.25em;
+  header {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 0.75em;
 
-    img.avatar {
-      border-radius: 50%;
-      box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.05);
-      grid-row-end: span 2;
-      height: 2.5em;
-      margin-right: 0.5em;
+    .account {
+      display: grid;
+
+      .avatar {
+        border-radius: 50%;
+        box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.05);
+        display: block;
+        grid-row-end: span 2;
+        height: 2.5em;
+        margin-right: 0.5em;
+      }
+
+      p,
+      strong {
+        font-size: 0.8em;
+        grid-column-start: 2;
+        line-height: 1.25;
+        margin: 0;
+      }
+
+      p {
+        opacity: 0.75;
+      }
     }
 
-    img.logo {
-      grid-column-start: 3;
-      grid-row-end: span 2;
-      grid-row-start: 1;
+    .logo {
       height: 1.25em;
-      justify-self: end;
       margin: 0;
-    }
-
-    p,
-    strong {
-      font-size: 0.8em;
-      grid-column-start: 2;
-      line-height: 1.25;
-      margin: 0;
-    }
-
-    strong {
-      align-self: end;
-    }
-
-    p {
-      align-self: start;
-      opacity: 0.75;
+      text-align: right;
     }
   }
 
-  .timestamp {
+  footer {
     font-size: 0.75em;
-    margin: 0;
-    opacity: 0.6;
+    line-height: 1;
+    margin-top: 1.5em;
+
+    a {
+      display: flex;
+      justify-content: space-between;
+      opacity: 0.6;
+    }
   }
 
   @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
Revisiting the Twitter cards to more closely follow the [Twitter Display Requirements](https://developer.twitter.com/en/developer-terms/display-requirements):

- Link the user stuff to the user's profile
- Link the Twitter logo to the permalink
- Add "View on Twitter"
- Right-align timestamp and link to permalink

It also means the text is more easily copy-able, since the whole thing is not a giant link. While I was here: 
- Improved contrast in the dark style.
- Slightly more semantic DOM w/`<header>`, `<footer>`, `<time>`, etc.

**This is a BREAKING CHANGE as it changes the format for the include.** I have updated the example include here, but the main changes are:

- Pass an `id` to the tweet instead of an `href`
- Omit the `@` in `account`
- Support for a proper consistently-formatted timestamp

We'll need to update the one Tweet include we have in the blog after merging this.

### Screenshots

Light | Dark
--- | ---
![Screenshot from 2020-07-17 10-52-36](https://user-images.githubusercontent.com/611168/87811305-b08e2800-c81b-11ea-8004-b1b8a919dabc.png) | ![Screenshot from 2020-07-17 10-52-43](https://user-images.githubusercontent.com/611168/87811303-aff59180-c81b-11ea-9093-b7a040c835fa.png)
