### PR TITLE
Typography: Prefer Inter

### DIFF
--- a/_sass/_typography.scss
+++ b/_sass/_typography.scss
@@ -1,7 +1,7 @@
 :root {
-  --ui-font: "Open Sans", "Noto Sans", "Roboto", "Droid Sans", sans-serif;
+  --ui-font: Inter, "Open Sans", "Noto Sans", "Roboto", "Droid Sans", sans-serif;
   --copy-font: "Noto Serif", "Droid Serif", serif;
-  --heading-font: Raleway, var(--ui-font);
+  --heading-font: Inter, Raleway, var(--ui-font);
 }
 
 html {


### PR DESCRIPTION
Add Inter to the beginning of the font stack. If a visitor has Inter installed (like in elementary OS 6), it'll prefer that; otherwise, it'll continue to use the existing font stack in fallback order.