### PR TITLE
[Feature] Optionally adds the image set in 'image' at the top of the post

### DIFF
--- a/_config.yaml
+++ b/_config.yaml
@@ -45,6 +45,8 @@ plugins:
 paginate: 7
 paginate_path: "/archive/:num/"
 
+show_top_thumbnail: false # Shows the image set in the front matter at the top of the posts
+
 markdown: kramdown
 kramdown:
   syntax_highlighter: rouge

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -31,8 +31,8 @@ layout: default
     {% if page.image %}
       {% if site.show_top_thumbnail or page.show_top_thumbnail %}
         {% unless page.show_top_thumbnail == false %}      
-          <figure>
-            <img class="featured-image" src="{{ page.image }}" alt="{{ page.image | split: '/' | last | split: '.' | first | replace: '-', ' ' }}" />
+          <figure class="post-thumbnail">
+            <img src="{{ page.image }}" alt="{{ page.image | split: '/' | last | split: '.' | first | replace: '-', ' ' }}" />
           </figure>
         {% endunless %}
       {% endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -28,6 +28,15 @@ layout: default
   </header>
 
   <section>
+    {% if page.image %}
+      {% if site.show_top_thumbnail or page.show_top_thumbnail %}
+        {% unless page.show_top_thumbnail == false %}      
+          <figure>
+            <img class="featured-image" src="{{ page.image }}" alt="{{ page.image | split: '/' | last | split: '.' | first | replace: '-', ' ' }}" />
+          </figure>
+        {% endunless %}
+      {% endif %}
+    {% endif %}
     {{ content }}
   </section>
 

--- a/_posts/1992-02-01-test.md
+++ b/_posts/1992-02-01-test.md
@@ -3,6 +3,7 @@ title:  "Just a Test Blog Post"
 description: "This is a test; this is only a test"
 author: cassidyjames
 image: https://source.unsplash.com/featured?test
+show_top_thumbnail: true
 tags:
   - test
   - meta


### PR DESCRIPTION
- This update allows to optionally use the value set in the `image` front matter as a featured image at the top of the posts.
- The feature is disabled by default. It can be enabled either site-wide or per page using `show_top_thumbnail: [BOOLEAN]`.
- The page value overrides the site value.
- The image is inserted within a `<figure>`, uses the `post-thumbnail` class, and automatically takes the file name as `alt` value. Example:

Input: 

`image: /uploads/2020/09/photo-of-my-cat.jpg`

Output:

```html
<figure class="post-thumbnail">
  <img src="/uploads/2020/09/photo-of-my-cat.jpg" alt="photo of my cat" />
</figure>
```
- `_posts/1992-02-01-test.md` has been updated to serve as an example.