### PR TITLE
Add meta tag to declare that the website supports dark style

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -18,6 +18,7 @@
 
   <meta name="author" content="{% if page.author.name %}{{ page.author.name }}{% else %}{{ site.author }}{% endif %}" />
   <meta name="theme-color" content="{% if page.theme-color %}{{ page.theme-color }}{% else %}{{ site.theme-color }}{% endif %}" />
+  <meta name="color-scheme" content="light dark" />
 
   {% if page.image %}
     {% assign prefix = page.image | slice: 0, 4 %}


### PR DESCRIPTION
Added the `color-scheme` meta tag to the head, to declare that this website can handle both light and dark themes.

This is important if there are any default controls (scrollbars, select boxes, inputs) that would use the browser style, and [some mobile browsers](https://medium.com/samsung-internet-dev/dark-mode-in-samsung-internet-7d6e974ba09e) use this information to verify if they should force a dark style or not for the website, therefore avoiding breakage in those browsers.

More docs around this meta tag: https://web.dev/color-scheme/#the-color-scheme-css-property