### PR TITLE
Fix "Older" right-arrow in pagination wrapping to new line

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -61,7 +61,6 @@ nav.pagination {
   text-align: center;
 
   a {
-    display: inline-block;
     font-size: 1rem;
     font-family: var(--ui-font);
     padding: 1em;


### PR DESCRIPTION
Fixes the "Older ->" right-arrow wrapping to a new line, for example at the bottom of https://blog.elementary.io.

Before/after testing the change after adding some more test posts to force the link to appear:
<img width="1110" alt="Screen Shot 2022-06-10 at 10 34 25 AM" src="https://user-images.githubusercontent.com/3663899/173111824-f48f77a8-b1ad-4bad-9c72-e5b979c2dfbe.png">
<img width="1229" alt="Screen Shot 2022-06-10 at 10 34 55 AM" src="https://user-images.githubusercontent.com/3663899/173111835-5a357289-363d-4d4f-9249-feebda971b68.png">

Also a before/after side-by-side with the "<- Newer" and "Older ->" links to show consistency:
<img width="1197" alt="Screen Shot 2022-06-10 at 10 39 26 AM" src="https://user-images.githubusercontent.com/3663899/173112317-c9c5e46c-37a1-48d7-a4da-ded92697aece.png">
<img width="1166" alt="Screen Shot 2022-06-10 at 10 38 39 AM" src="https://user-images.githubusercontent.com/3663899/173112246-b3a5a379-53d4-44b6-be0a-818078c55595.png">

